### PR TITLE
Fix for thrd-posix-2 in CH4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ This contains source code for the 9th edition of
 Published by John Wiley & Sons.
 
 Additions made by Liam Paull at University of Montreal for the class IFT2245.
+Some fixes by Samuel Yvon at University of Montreal for the class IFT2245.
+
 
 Source files are organized by Chapter. (Each chapter has a
 separate README file.)

--- a/ch4/thrd-posix-2.c
+++ b/ch4/thrd-posix-2.c
@@ -1,6 +1,6 @@
 /**
 
- */
+*/
 
 #include <pthread.h>
 #include <stdio.h>
@@ -19,9 +19,9 @@ struct interval {
 int main(int argc, char *argv[])
 {
   pthread_attr_t attr; /* set of attributes for the thread */
-  pthread_t tid[num_threads]; /* the thread identifier */
+  pthread_t *tid;
 
-  
+
   if (argc != 3) {
     fprintf(stderr,"usage: a.out <integer value> <num threads> \n");
     /*exit(1);*/
@@ -35,16 +35,21 @@ int main(int argc, char *argv[])
   }
 
   num_threads = atoi(argv[2]);
+  /* the thread identifier */
+  if(NULL == (tid = malloc(sizeof(pthread_t) * num_threads))) {
+      printf("Out of memory!\n");
+      exit(-1);
+  }
+
   int j;
   sum = 0;
   int start = 1;
   int input = atoi(argv[1]);
   int end = input/num_threads;
-  
+
   for(j=0;j<num_threads;j++){
     /* get the default attributes */
     pthread_attr_init(&attr);
-
 
     struct interval* inter = malloc(sizeof(struct interval));
     inter->start = start;
@@ -56,13 +61,15 @@ int main(int argc, char *argv[])
     end = end + input/num_threads;
   }
 
-  
 
   for(j=0;j<num_threads;j++){
     /* now wait for the thread to exit */
     pthread_join(tid[j],NULL);
   }
-  
+
+
+  free(tid);
+
   printf("sum = %d\n",sum);
   return 0;
 }
@@ -73,7 +80,7 @@ void *runner(void* input_interval)
   int i;
 
   printf("Start = %d, end = %d \n", inter->start, inter->end);
-  
+
   for (i = inter->start; i <= inter->end; i++)
     sum += i;
 


### PR DESCRIPTION
The example in `thrd-posix-2.c` shows how a variable number of threads can be used to perform a long running computation. However, the original authors have initialized the thread array to a size with an uninitialized value (the number of threads). Therefore, the example did not work and students reported, as expected, erratic behavior. 

I fixed the example by allocating the thread structures in the heap.

Thanks to Antoine Colson for reporting this example was running strange.